### PR TITLE
Update app names and readme because underscores not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,29 @@ Take a look at this [blog post](https://blog.pivotal.io/data-science-pivotal/pro
 
 ## Deploying the app on Pivotal Cloud Foundry
 
-    1) Update the 3 application names in manifest.yml
-        - Name of dashboard/sensor app
-        - Name of training app
-        - Name of scoring app
+### 1. Update the 3 application names in manifest.yml
 
-    2) Edit file "moves-app/moves/static/js/movesParams.js" to reflect route 
-    names of training and scoring applications
+These app names will become part of the domain URLs, so change as desired.
+ 
+    ...
+    name: DASHBOARD-APP-NAME
+    ...
+    name: TRAINING-APP-NAME
+    ...
+    name: SCORING-APP-NAME
+    ...
 
-    3) cf create-service p-redis shared-vm moves-redis
-       cf push
+*Note that underscores are not allowed in the app names. Cloud Foundry automatically converts them to dashes, which disrupts URL routing.*
+
+### 2. Update parameters in JavaScript
+
+Edit file "moves-app/moves/static/js/movesParams.js" to reflect route 
+names of training and scoring applications as specified in previous step. 
+
+### 3. Create redis service and push application
+
+    cf create-service p-redis shared-vm moves-redis
+    cf push
 
 This has been tested using Pivotal [PEZ](https://apps.run.pez.pivotal.io/)
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
   command: python runserver.py
   disk_quota: 1024MB
   memory: 1024MB
-  name: NAMEOFMOVES
+  name: DASHBOARD-APP-NAME
   random-route: false
   path: ./moves-app
   services:
@@ -12,7 +12,7 @@ applications:
   command: python train_app.py
   instances: 1
   memory: 1024M
-  name: NAMEOFTRAININGAPP
+  name: TRAINING-APP-NAME
   path: ./train-app
   random-route: false
   services:
@@ -21,7 +21,7 @@ applications:
   command: python score_app.py
   instances: 1
   memory: 1024M
-  name: NAMEOFSCORINGAPP
+  name: SCORING-APP-NAME
   path: ./score-app
   random-route: false
   services:

--- a/moves-app/moves/static/js/movesParams.js
+++ b/moves-app/moves/static/js/movesParams.js
@@ -1,4 +1,4 @@
 movesParams = {
-    "trainAppUrl": "http://NAME_OF_TRAINING_APP.cfapps.pez.pivotal.io", 
-    "scoreAppUrl": "http://NAME_OF_SCORING_APP.cfapps.pez.pivotal.io"
+    "trainAppUrl": "http://TRAINING-APP-NAME.cfapps.pez.pivotal.io",
+    "scoreAppUrl": "http://SCORING-APP-NAME.cfapps.pez.pivotal.io"
 }


### PR DESCRIPTION
Cloud Foundry allows app names to contain underscores, but it converts them to dashes when creating app domain names. This was throwing off routing, so change the default app names and the README to warn against using underscores.
