### PR TITLE
Pin eventlet to v0.19.0

### DIFF
--- a/moves-app/requirements.txt
+++ b/moves-app/requirements.txt
@@ -1,4 +1,4 @@
-eventlet
+eventlet == 0.19.0
 flask-socketio
 Flask
 redis


### PR DESCRIPTION
A bug in eventlet v20 or 21 caused the app to fail. Would get this error:

Exception AttributeError: "'_SocketDuckForFd' object has no attribute '_closed'" in <bound method _SocketDuckForFd.__del__ of _SocketDuckForFd:9>

Seems related to issue 401: new monotonic broken on docker?
https://github.com/eventlet/eventlet/issues/401